### PR TITLE
Fix snips of member functions by switching snip option from 'i' to 'w'

### DIFF
--- a/autoload/ncm2_ultisnips.vim
+++ b/autoload/ncm2_ultisnips.vim
@@ -42,7 +42,7 @@ func! ncm2_ultisnips#_do_expand_completed()
     py3 apply_additional_text_edits(vim.eval('json_encode(l:completed)'))
     let snippet = ud.ultisnips_snippet
     let trigger = ud.snippet_word
-    let ret = UltiSnips#Anon(snippet, trigger, 'i', 'i')
+    let ret = UltiSnips#Anon(snippet, trigger, '', 'w')
     call feedkeys("\<Plug>(ncm2_skip_auto_trigger)", "m")
     return ret
 endfunc


### PR DESCRIPTION
https://github.com/ncm2/ncm2-ultisnips/blob/15432d7933cfb855599442a67d6f39ddb706c737/autoload/ncm2_ultisnips.vim#L45

Here passes the option `i` to ultisnips. From the doc it requires the trigger text is at the beginning of the line or is preceded by whitespaces, so member functions, e.g. `vector.push_back(...)`, cannot be completed, since the completed item only contains `push_back(...)` and it doesn't meet the requirement of option `i`.

Also, there are two `i`s in this line, the first `i` should be the description, which is unused at this point from UltiSnips' doc. Two `i`s are confusing and unnecessary, so I replaced the first `i` with `""`